### PR TITLE
Surface boundary issue solved

### DIFF
--- a/polysurfdemo_public.m
+++ b/polysurfdemo_public.m
@@ -145,7 +145,7 @@ surfu = 50;
 surfv = 50;
 
 disp('Generating surface ...')
-[Gx,Gy,Gz] = polysurf(P,surfu,surfv);
+[Gx,Gy,Gz] = polysurf(P,surfu,surfv,1);
 
 hold on
 % plot3(Gx,Gy,Gz,'.')

--- a/polysurfdemo_random.m
+++ b/polysurfdemo_random.m
@@ -56,7 +56,7 @@ P{4} = G1v; % G(1,v)
 % P{1},P{2},P{3},P{4}
 
 % Generate the bilinear surface G(u,v)
-[Gx,Gy,Gz] = polysurf(P,surfu,surfv);
+[Gx,Gy,Gz] = polysurf(P,surfu,surfv,1);
 
 % 3-d plot    
 fh3d = figure('name','3-d plot');


### PR DESCRIPTION
It is now possible to include the polylines control points on the final
surface boundaries. This was solved by injecting the line segment
parameters into the surface parameter grids u and v. This new feature
can be invoked by setting matchBoundaries=1 in the polysurf function.
